### PR TITLE
Fix default type for paid leave

### DIFF
--- a/kit_timesheet.typ
+++ b/kit_timesheet.typ
@@ -483,7 +483,7 @@
   }
 
   let monthly = duration(hours: monthly_hours)
-  let holiday = entries.filter(e => e.note == notes.Urlaub).map(e => e.duration).sum(default: duration(seconds: 0))
+  let holiday = entries.filter(e => e.note == notes.Urlaub).map(e => e.duration).sum(default: duration())
   let total = entries.map(e => e.duration).sum(default: duration())
   let carry_next_month = carry_prev_month + total - monthly
 

--- a/kit_timesheet.typ
+++ b/kit_timesheet.typ
@@ -483,7 +483,7 @@
   }
 
   let monthly = duration(hours: monthly_hours)
-  let holiday = entries.filter(e => e.note == notes.Urlaub).map(e => e.duration).sum(default: 0)
+  let holiday = entries.filter(e => e.note == notes.Urlaub).map(e => e.duration).sum(default: duration(seconds: 0))
   let total = entries.map(e => e.duration).sum(default: duration())
   let carry_next_month = carry_prev_month + total - monthly
 


### PR DESCRIPTION
The previous default type of `0` holidays caused problems in the `_fmt_duration` method. I changed it to an empty duration.